### PR TITLE
Fix build for Termux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def _find_library_dirs_ldconfig():
                                  stdout=subprocess.PIPE,
                                  env=env)
     except OSError:  # E.g. command not found
-        return None
+        return []
     [data, _] = p.communicate()
     if isinstance(data, bytes):
         data = data.decode()


### PR DESCRIPTION
Now `_find_library_dirs_ldconfig` returns an empty list when `ldconfig` is missing, then `setup.py` can continue guessing library directories.

Fixes #3526.
